### PR TITLE
Added multiple arguments feature

### DIFF
--- a/_poly-fluid-sizing.scss
+++ b/_poly-fluid-sizing.scss
@@ -13,7 +13,7 @@
 /// @example
 ///   @include poly-fluid-sizing('font-size', (576px: 22px, 768px: 24px, 992px: 34px));
 /// @author Jake Wilson <jake.e.wilson@gmail.com>
-@mixin poly-fluid-sizing($property, $map) {
+@mixin poly-fluid-sizing($properties, $map) {
   // Get the number of provided breakpoints
   $length: length(map-keys($map));
 
@@ -26,25 +26,27 @@
   $map: map-sort($map);
   $keys: map-keys($map);
 
-  // Minimum size
-  #{$property}: map-get($map, nth($keys,1));
+  @each $property in $properties {
+    // Minimum size
+    #{$property}: map-get($map, nth($keys,1));
 
-  // Interpolated size through breakpoints
-  @for $i from 1 through ($length - 1) {
-    @media (min-width:nth($keys,$i)) {
-      $value1: map-get($map, nth($keys,$i));
-      $value2: map-get($map, nth($keys,($i + 1)));
-      // If values are not equal, perform linear interpolation
-      @if ($value1 != $value2) {
-        #{$property}: linear-interpolation((nth($keys,$i): $value1, nth($keys,($i+1)): $value2));
-      } @else {
-        #{$property}: $value1;
+    // Interpolated size through breakpoints
+    @for $i from 1 through ($length - 1) {
+      @media (min-width:nth($keys,$i)) {
+        $value1: map-get($map, nth($keys,$i));
+        $value2: map-get($map, nth($keys,($i + 1)));
+        // If values are not equal, perform linear interpolation
+        @if ($value1 != $value2) {
+          #{$property}: linear-interpolation((nth($keys,$i): $value1, nth($keys,($i+1)): $value2));
+        } @else {
+          #{$property}: $value1;
+        }
       }
     }
-  }
 
-  // Maxmimum size
-  @media (min-width:nth($keys,$length)) {
-    #{$property}: map-get($map, nth($keys,$length));
+    // Maxmimum size
+    @media (min-width:nth($keys,$length)) {
+      #{$property}: map-get($map, nth($keys,$length));
+    }
   }
 }


### PR DESCRIPTION
Added an `@each` loop to allow multiple arguments. Now you can write one line for properties that have matching values.

From:
```
@include poly-fluid-sizing(padding-right, (1600px:60px, 523px:30px));
@include poly-fluid-sizing(padding-left, (1600px:60px, 523px:30px));
```
To:
`@include poly-fluid-sizing(padding-left padding-right, (1600px:60px, 523px:30px));`