### PR TITLE
removed deprecated slash div

### DIFF
--- a/_linear-interpolation.scss
+++ b/_linear-interpolation.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 /// linear-interpolation
 /// Calculate the definition of a line between two points
 /// @param $map - A SASS map of viewport widths and size value pairs
@@ -11,7 +13,7 @@
     @error "linear-interpolation() $map must be exactly 2 values";
   }
   // The slope
-  $m: (map-get($map, nth($keys, 2)) - map-get($map, nth($keys, 1)))/(nth($keys, 2) - nth($keys,1));
+  $m: math.div(map-get($map, nth($keys, 2)) - map-get($map, nth($keys, 1)), nth($keys, 2) - nth($keys,1));
 
   // The y-intercept
   $b: map-get($map, nth($keys, 1)) - $m * nth($keys, 1);


### PR DESCRIPTION
The / operator has been deprecated, and Sass has introduced two new functions math.div() and list.slash(). So, I have removed the / operator for division and updated the _linear_interpolation.scss file with the math.div() function.