### PR TITLE
Switch to `@use` and namespaced list/map functions

### DIFF
--- a/_linear-interpolation.scss
+++ b/_linear-interpolation.scss
@@ -1,3 +1,5 @@
+@use "sass:list";
+@use "sass:map";
 @use "sass:math";
 
 /// linear-interpolation
@@ -8,15 +10,15 @@
 ///   font-size: linear-interpolation((320px: 18px, 768px: 26px));
 /// @author Jake Wilson <jake.e.wilson@gmail.com>
 @function linear-interpolation($map) {
-  $keys: map-keys($map);
-  @if (length($keys) != 2) {
+  $keys: map.keys($map);
+  @if (list.length($keys) != 2) {
     @error "linear-interpolation() $map must be exactly 2 values";
   }
   // The slope
-  $m: math.div(map-get($map, nth($keys, 2)) - map-get($map, nth($keys, 1)), nth($keys, 2) - nth($keys,1));
+  $m: math.div(map.get($map, list.nth($keys, 2)) - map.get($map, list.nth($keys, 1)), list.nth($keys, 2) - list.nth($keys,1));
 
   // The y-intercept
-  $b: map-get($map, nth($keys, 1)) - $m * nth($keys, 1);
+  $b: map.get($map, list.nth($keys, 1)) - $m * list.nth($keys, 1);
 
   // Determine if the sign should be positive or negative
   $sign: "+";

--- a/_list-remove.scss
+++ b/_list-remove.scss
@@ -1,3 +1,5 @@
+@use "sass:list";
+
 /// list-remove
 /// Remove an item from a list
 /// @param $list - A SASS list
@@ -6,9 +8,9 @@
 /// @author Jake Wilson <jake.e.wilson@gmail.com>
 @function list-remove($list, $index) {
   $newList: ();
-  @for $i from 1 through length($list) {
+  @for $i from 1 through list.length($list) {
     @if $i != $index {
-      $newList: append($newList, nth($list,$i), 'space');
+      $newList: list.append($newList, list.nth($list,$i), 'space');
     }
   }
   @return $newList;

--- a/_list-sort.scss
+++ b/_list-sort.scss
@@ -1,3 +1,6 @@
+@use "sass:list";
+@use "list-remove";
+
 /// list-sort
 /// Sort a SASS list
 /// @param $list - A SASS list
@@ -6,15 +9,15 @@
 /// @author Jake Wilson <jake.e.wilson@gmail.com>
 @function list-sort($list) {
   $sortedlist: ();
-  @while length($list) > 0 {
-    $value: nth($list,1);
+  @while list.length($list) > 0 {
+    $value: list.nth($list,1);
     @each $item in $list {
       @if $item < $value {
         $value: $item;
       }
     }
-    $sortedlist: append($sortedlist, $value, 'space');
-    $list: list-remove($list, index($list, $value));
+    $sortedlist: list.append($sortedlist, $value, 'space');
+    $list: list-remove.list-remove($list, list.index($list, $value));
   }
   @return $sortedlist;
 }

--- a/_map-sort.scss
+++ b/_map-sort.scss
@@ -1,3 +1,6 @@
+@use "sass:map";
+@use "list-sort";
+
 /// map-sort
 /// Sort map by keys
 /// @param $map - A SASS map
@@ -5,10 +8,10 @@
 /// @requires function list-sort
 /// @author Jake Wilson <jake.e.wilson@gmail.com>
 @function map-sort($map) {
-  $keys: list-sort(map-keys($map));
+  $keys: list-sort.list-sort(map.keys($map));
   $sortedMap: ();
   @each $key in $keys {
-    $sortedMap: map-merge($sortedMap, ($key: map-get($map, $key)));
+    $sortedMap: map.merge($sortedMap, ($key: map.get($map, $key)));
   }
   @return $sortedMap;
 }

--- a/_poly-fluid-sizing.scss
+++ b/_poly-fluid-sizing.scss
@@ -1,8 +1,11 @@
+@use 'sass:list';
+@use 'sass:map';
+
 // Dependency functions
-@import 'list-remove';
-@import 'list-sort';
-@import 'map-sort';
-@import 'linear-interpolation';
+@use 'list-remove';
+@use 'list-sort';
+@use 'map-sort';
+@use 'linear-interpolation';
 
 /// poly-fluid-sizing
 /// Generate linear interpolated size values through multiple break points
@@ -17,7 +20,7 @@
   $result: ();
 
   // Get the number of provided breakpoints
-  $length: length(map-keys($map));
+  $length: list.length(map.keys($map));
 
   // Error if the number of breakpoints is < 2
   @if ($length < 2) {
@@ -25,40 +28,40 @@
   }
 
   // Sort the map by viewport width (key)
-  $map: map-sort($map);
-  $keys: map-keys($map);
+  $map: map-sort.map-sort($map);
+  $keys: map.keys($map);
 
   // Minimum size
-  #{$property}: map-get($map, nth($keys, 1));
+  #{$property}: map.get($map, list.nth($keys, 1));
 
   // Interpolated size through breakpoints
   @for $i from 1 through ($length - 1) {
     $result: ();
-    $low-values: map-get($map, nth($keys, $i));
-    $high-values: map-get($map, nth($keys, ($i + 1)));
-    $total: length($low-values);
-    $low-separator: list-separator(nth($keys, $i));
-    $high-separator: list-separator(nth($keys, $i + 1));
+    $low-values: map.get($map, list.nth($keys, $i));
+    $high-values: map.get($map, list.nth($keys, ($i + 1)));
+    $total: list.length($low-values);
+    $low-separator: list.separator(list.nth($keys, $i));
+    $high-separator: list.separator(list.nth($keys, $i + 1));
 
     @if ($low-separator != $high-separator) {
       @error "poly-fluid-sizing() values must use the same separator";
     }
 
-    @media (min-width:nth($keys, $i)) {
-      @if (length($low-values) != length($high-values)) {
+    @media (min-width:list.nth($keys, $i)) {
+      @if (list.length($low-values) != list.length($high-values)) {
         @error "poly-fluid-sizing() values must have same number args";
       }
 
       @for $j from 1 through $total {
-        $value1: nth($low-values, $j);
-        $value2: nth($high-values, $j);
-        $key1: nth($keys, $i);
-        $key2: nth($keys, $i + 1);
+        $value1: list.nth($low-values, $j);
+        $value2: list.nth($high-values, $j);
+        $key1: list.nth($keys, $i);
+        $key2: list.nth($keys, $i + 1);
 
         @if ($value1 != $value2) {
-          $result: append($result, linear-interpolation(($key1: $value1, $key2: $value2)), $low-separator);
+          $result: list.append($result, linear-interpolation.linear-interpolation(($key1: $value1, $key2: $value2)), $low-separator);
         } @else {
-          $result: append($result, $value1, $low-separator);
+          $result: list.append($result, $value1, $low-separator);
         }
       }
 
@@ -67,7 +70,7 @@
   }
 
   // Maxmimum size
-  @media (min-width:nth($keys,$length)) {
-    #{$property}: map-get($map, nth($keys,$length));
+  @media (min-width:list.nth($keys,$length)) {
+    #{$property}: map.get($map, list.nth($keys,$length));
   }
 }


### PR DESCRIPTION
Fixes #11

1. Replaced legacy function calls with namespaced list (`@use "sass:list";`)
- `length` -> `list.length`
- `nth` -> `list.nth`
- `append` -> `list.append`
- `index` -> `list.index`
- `list-separator` -> `list.separator`

and namespaced map (`@use "sass:map";`) functions:
- `map-get` -> `map.get`
- `map-keys` -> `map.keys`
- `map-merge` -> `map.merge`
- `map-sort` -> `map.sort`

This resolves the the following deprecation warning for each occurrence of legacy function:
```
Deprecation Warning [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
```


2. Replaced `@import` with `@use` directive.
- `@import 'list-remove';` -> `@use 'list-remove';`
- `@import 'list-sort';` -> `@use 'list-sort';`
- `@import 'map-sort';` -> `@use 'map-sort';`
- `@import 'linear-interpolation';` -> `@use 'linear-interpolation';`


Since `@use` namespaces the imported file, the imports for internal functions were changed:
- `list-remove` -> `list-remove.list-remove`
- `map-sort` -> `map-sort.map-sort`
- `linear-interpolation` -> `linear-interpolation.linear-interpolation`

This resolves the following deprecation warning for each occurrence of `@import`:
```
Deprecation Warning [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.
```